### PR TITLE
Delete extra indent each components. Because ShowkaseRooterCodegen's …

### DIFF
--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/ShowkaseBrowserWriter.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/ShowkaseBrowserWriter.kt
@@ -108,6 +108,7 @@ internal class ShowkaseBrowserWriter(private val environment: XProcessingEnv) {
 
     private fun CodeBlock.Builder.addProviderComponent(withParameterMetadata: ShowkaseMetadata.Component) {
         addLineBreak()
+        unindent()
         add(
             "%T()",
             withParameterMetadata.previewParameterProviderType


### PR DESCRIPTION
…generate component tabs step increase.